### PR TITLE
graceful fallback for non-blessed unit strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- fixed crash if unknown units strings were provided
+
 ## [2022.7.0]
 
 ### Fixed

--- a/qtypes/_units.py
+++ b/qtypes/_units.py
@@ -1,26 +1,10 @@
-"""Unit and label handling in WrightTools."""
-
-
-# --- import --------------------------------------------------------------------------------------
-
-
 from typing import Optional
 import warnings
+
 
 import pint
 
 
-# --- define --------------------------------------------------------------------------------------
-
-# Thise "blessed" units are here primarily for backwards compatibility, in particular
-# to enable the behavior of `data.convert` which will convert freely between the energy units
-# but does not go to time (where delay will)
-# Since both of these context can convert to [length] units, they are interconvertible, but we
-# do not want them to automatically do so.
-# This list is (at creation time) purely reflective of historical units supported pre pint
-# There is nothing preventing other units from being used and converted to, only to enable
-# expected behavior
-# 2021-01-29 KFS
 blessed_units = (
     # angle
     "rad",
@@ -91,8 +75,6 @@ delay.add_transformation(
     "[time]", "[length]", lambda ureg, x, n=1, num_pass=2: x / num_pass * ureg.speed_of_light / n
 )
 ureg.enable_contexts("spectroscopy", delay)
-
-# --- functions -----------------------------------------------------------------------------------
 
 
 def converter(val, current_unit, destination_unit):

--- a/qtypes/_widgets/_float.py
+++ b/qtypes/_widgets/_float.py
@@ -49,7 +49,12 @@ class Widget(QtWidgets.QWidget):
         # units
         if data["units"] is not None and len(self.allowed_units) == 0:
             self.combo_box.currentIndexChanged.disconnect(self.on_combo_box_editing_finished)
-            self.combo_box.addItems(get_valid_conversions(data["units"]))
+            options = get_valid_conversions(data["units"])
+            if data["units"] not in options:
+                options = list(options)
+                options.append(data["units"])
+            self.combo_box.setDisabled(len(options) == 1)
+            self.combo_box.addItems(options)
             self.combo_box.currentIndexChanged.connect(self.on_combo_box_editing_finished)
         if data["units"] is not None:
             self.combo_box.show()


### PR DESCRIPTION
Current distributed qtypes will actually crash if unit string isn't blessed. This changes that behavior, now the non-blessed unit will appear for information but no conversions will be allowed.