### PR TITLE
force widgets to ignore mouse wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- enum, float, and integer now ignore mouse wheel
+
 ## [2022.11.0]
 
 ### Fixed

--- a/qtypes/_widgets/_enum.py
+++ b/qtypes/_widgets/_enum.py
@@ -4,11 +4,19 @@ from qtpy import QtWidgets, QtGui, QtCore
 class Widget(QtWidgets.QComboBox):
     def __init__(self, model, parent):
         super().__init__(parent=parent)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.installEventFilter(self)
         self.currentTextChanged.connect(self.on_current_text_changed)
         # wire into model
         self.model = model
         self.model.updated_connect(self.on_updated)
         self.on_updated(model.get())
+
+    def eventFilter(self, obj, event):
+        if isinstance(event, QtGui.QWheelEvent):
+            return True
+        else:
+            return super().eventFilter(obj, event)
 
     def updated_disconnect(self):
         self.model.updated_disconnect(self.on_updated)

--- a/qtypes/_widgets/_float.py
+++ b/qtypes/_widgets/_float.py
@@ -6,7 +6,6 @@ from .._units import converter, get_valid_conversions
 
 
 class DoubleSpinNoWheel(QtWidgets.QDoubleSpinBox):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setFocusPolicy(QtCore.Qt.StrongFocus)

--- a/qtypes/_widgets/_float.py
+++ b/qtypes/_widgets/_float.py
@@ -5,12 +5,26 @@ from qtpy import QtWidgets, QtGui, QtCore
 from .._units import converter, get_valid_conversions
 
 
+class DoubleSpinNoWheel(QtWidgets.QDoubleSpinBox):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if isinstance(event, QtGui.QWheelEvent):
+            return True
+        else:
+            return super().eventFilter(obj, event)
+
+
 class Widget(QtWidgets.QWidget):
     def __init__(self, model, parent):
         super().__init__(parent=parent)
         # build widget
         self.setLayout(QtWidgets.QHBoxLayout())
-        self.spin_box = QtWidgets.QDoubleSpinBox()
+        self.spin_box = DoubleSpinNoWheel()
         self.layout().addWidget(self.spin_box)
         self.combo_box = QtWidgets.QComboBox()
         self.combo_box.setFixedWidth(100)

--- a/qtypes/_widgets/_integer.py
+++ b/qtypes/_widgets/_integer.py
@@ -4,11 +4,19 @@ from qtpy import QtWidgets, QtGui, QtCore
 class Widget(QtWidgets.QSpinBox):
     def __init__(self, model, parent):
         super().__init__(parent=parent)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.installEventFilter(self)
         self.editingFinished.connect(self.on_editing_finished)
         # wire into model
         self.model = model
         self.model.updated_connect(self.on_updated)
         self.on_updated(model.get())
+
+    def eventFilter(self, obj, event):
+        if isinstance(event, QtGui.QWheelEvent):
+            return True
+        else:
+            return super().eventFilter(obj, event)
 
     def updated_disconnect(self):
         self.model.updated_disconnect(self.on_updated)


### PR DESCRIPTION
This has been something many people have complained about, and I think it's all fixed now.

Small changes, but it took a while to find out which changes to make... event filters are cool I'm thinking about other ways to use them. Especially because you can add your own events.

@ksunden assuming you review you should check out this branch and make sure it works well for you